### PR TITLE
fix(web/DigitDazzle): Success with wrong code

### DIFF
--- a/web/src/components/DigitDazzle.svelte
+++ b/web/src/components/DigitDazzle.svelte
@@ -86,8 +86,9 @@ function clearCleanUpFunctions() {
 
             let timerDone = false;
             let durationCheck = setTimeout(() => {
-                finish(false);
                 timerDone = true;
+                if (CheckingCode) return;
+                finish(false);
             }, DigitDazeState.duration + 500);
 
             CleanUpFunctions.push(() => {
@@ -116,8 +117,10 @@ function clearCleanUpFunctions() {
 
             SuccessChecker = async () => {
                 const result = await check();
-                if (result || timerDone) {
+                if (result) {
                     finish(true);
+                } else if (timerDone) {
+                    finish(false);
                 }
             };
 


### PR DESCRIPTION
Minigame was being completed successfully if time ended when the code was being checked.

### Steps to reproduce
1. Start the minigame
2. Input wrong code
3. Right before the time finishes click "Crack"

### Changes
Ignore `durationCheck` finish call if `CheckingCode` is true
Split `SuccessChecker` conditions to return false if `timerDone` is true