### PR TITLE
fix(web/WordWizz): Minigame becoming unresponsive

### DIFF
--- a/web/src/components/WordWiz.svelte
+++ b/web/src/components/WordWiz.svelte
@@ -79,7 +79,11 @@ function clearCleanUpFunctions() {
             if (timeout) clearTimeout(timeout);
         })
         return new Promise((resolve, _) => {
+
+            let timerDone = false;
             let durationCheck = setTimeout(() => {
+                timerDone = true;
+                if (CheckingCode) return;
                 finish(false);
             }, WordWizState.duration + 500);
 
@@ -110,6 +114,8 @@ function clearCleanUpFunctions() {
                 const result = await check();
                 if (result) {
                     finish(true);
+                } else if (timerDone) {
+                    finish(false);
                 }
             };
 


### PR DESCRIPTION
Minigame becomes unresponsive if time ended when the code was being checked.

### Steps to reproduce
1. Start the minigame
2. Input wrong code
3. Right before the time finishes click "Crack"

### Changes (Same fix as https://github.com/Byte-Labs-Studio/bl_ui/pull/5)
Ignore `durationCheck` `finish` call if `CheckingCode` is true
Split `SuccessChecker` conditions to return false if `timerDone` is true