### PR TITLE
fix(web): Digit dazzle and word wizz input transition

### DIFF
--- a/web/src/components/DigitDazzle.svelte
+++ b/web/src/components/DigitDazzle.svelte
@@ -355,9 +355,9 @@ function clearCleanUpFunctions() {
                                 ? 'bg-warning/25 shadow-warning border border-warning'
                                 : ' primary-bg'}"
                     >
-                        {#if code !== undefined}
+                        {#if code.code}
                             <p transition:scale={{ duration: 250 }}>
-                                {code.code !== null ? code.code : ''}
+                                {code.code}
                             </p>
                         {/if}
                     </div>

--- a/web/src/components/WordWiz.svelte
+++ b/web/src/components/WordWiz.svelte
@@ -354,9 +354,9 @@ function clearCleanUpFunctions() {
                                   ? 'bg-warning/25 shadow-warning border border-warning'
                                   : ' primary-bg'}"
                     >
-                        {#if code !== undefined}
+                        {#if code.letter}
                             <p transition:scale={{ duration: 250 }}>
-                                {code.letter !== null ? code.letter : ''}
+                                {code.letter}
                             </p>
                         {/if}
                     </div>


### PR DESCRIPTION
### Issue
Content changes within the element itself do not trigger transitions 
### Fix
From my understating `code` will never be undefined so we can just check for the existance of user input remove the p tag if its null. This will cause mount and unmount triggering the transition