### PR TITLE
feat(digitdazzle): Allow setting code through export

### DIFF
--- a/_types.lua
+++ b/_types.lua
@@ -11,6 +11,10 @@
 ---@field length number The length of the circle's cuts
 ---@field duration number duration before game closes
 
+---@class InputConfig : LengthConfig
+---@field code? string[] Required if length is not defined
+---@field length? number Required if code is not defined
+
 ---@class LevelConfig
 ---@field level number The length of the circle's cuts
 ---@field duration number duration before game closes

--- a/client/games/digitDazzle.lua
+++ b/client/games/digitDazzle.lua
@@ -1,5 +1,5 @@
 ---@param iterations number The amount of iterations to run
----@param config LengthConfig
+---@param config InputConfig
 local function digitDazzle(iterations, config)
     local promise = promise:new()
 

--- a/web/src/components/DigitDazzle.svelte
+++ b/web/src/components/DigitDazzle.svelte
@@ -3,7 +3,7 @@
     import { GameType } from '@enums/gameTypes';
     import HackWrapper from '@lib/HackWrapper.svelte';
     import GAME_STATE from '@stores/GAME_STATE';
-    import type { TLengthHackGameParam, TLevelState } from '@typings/gameState';
+    import type { TInputHackGameParam, TLevelState } from "@typings/gameState";
     import type {
         TDigitDazzleCode,
         TDigitDazzleGameState,
@@ -170,7 +170,7 @@ function clearCleanUpFunctions() {
      * @param iterations The number of iterations to play.
      * @param difficulty The difficulty of the game.
      */
-    async function startGame(iterations: number, config: TLengthHackGameParam) {
+    async function startGame(iterations: number, config: TInputHackGameParam) {
         if (!Visible) return;
 
         SuccessChecker = null;
@@ -184,8 +184,18 @@ function clearCleanUpFunctions() {
 
         const duration = getRandomIntFromIntOrArray(config.duration);
 
-        CodeLength = getCodeLength(config.length);
-        const code = generateCode(CodeLength);
+        let code: number[]
+
+        if (config.length) {
+            CodeLength = getCodeLength(config.length);
+			code = generateCode(CodeLength);
+        } else {
+            const index = config.code.length - iterations
+            const input = config.code[index].toString()
+
+            CodeLength = input.length;
+            code = Array.from(input).map(Number);
+        }
 
         UserCode = Array.from({ length: CodeLength }, () => ({
             code: null,
@@ -252,7 +262,7 @@ function clearCleanUpFunctions() {
 
         const { iterations, config } = $GAME_STATE;
         Iterations = iterations;
-        startGame(iterations, config as TLengthHackGameParam);
+        startGame(iterations, config as TInputHackGameParam);
     }
 
     function generateCode(length: number) {

--- a/web/src/providers/Debug.svelte
+++ b/web/src/providers/Debug.svelte
@@ -44,7 +44,7 @@
 
                                     <input
                                         type="text"
-                                        class="h-full w-full px-[0.25vw]"
+                                        class="h-full w-full px-[0.25vw] text-black"
                                         bind:value={action.value}
                                     />
                                     <button

--- a/web/src/typings/gameState.ts
+++ b/web/src/typings/gameState.ts
@@ -34,6 +34,10 @@ export type TLengthHackGameParam = THackGameParam & {
     length: number | [number, number];
 }
 
+export type TInputHackGameParam = THackGameParam &
+    ({ code: string[] | number[]; length?: number | [number, number] }
+    | { code?: string[] | number[]; length: number | [number, number] });
+
 export type TGridHackGameParam = THackGameParam & {
     /** The size fo the grid to play. If its an array, the first number is the min size and the second is the max size. when randomized */
     grid: number | [number, number];

--- a/web/src/utils/debug/senders.ts
+++ b/web/src/utils/debug/senders.ts
@@ -2,7 +2,7 @@ import { DebugItem } from '@typings/events'
 import { toggleVisible } from './visibility'
 import { Receive } from '@enums/events'
 import { DebugEventSend } from '@utils/eventsHandlers'
-import type { TGameParams, TKeyGameParam, TDifficultyParam, TNodeHackGameParam, TLevelHackGameParam, TLengthHackGameParam, TGridHackGameParam } from '@typings/gameState'
+import type { TGameParams, TKeyGameParam, TDifficultyParam, TNodeHackGameParam, TLevelHackGameParam, TLengthHackGameParam, TGridHackGameParam, TInputHackGameParam } from '@typings/gameState'
 import { GameType } from '@enums/gameTypes'
 
 /**
@@ -273,6 +273,23 @@ const SendDebuggers: DebugItem[] = [
                 min: 1,
                 max: 12,
                 type: 'slider',
+            },
+            {
+                label: 'Input',
+                action: (value: number) => {
+                    const config = {
+                        duration: 20000,
+                        code: [value, value],
+                    } as TInputHackGameParam;
+
+                    DebugEventSend<TGameParams>(Receive.start, {
+                        type: GameType.DigitDazzle,
+                        iterations: 2,
+                        config,
+                    });
+                },
+                value: 1234,
+                type: 'text',
             },
         ],
     },


### PR DESCRIPTION
```lua
local success = exports.bl_ui:DigitDazzle(3, {
    code = {5671, 1234, 4321},
    duration = 60000,
})
```

Code array length matching iterations is assumed
Tried making the types generic as they can also be used on wordwizz